### PR TITLE
Added support for sending a list of messages to SendAsync

### DIFF
--- a/laget.Azure.ServiceBus.Tests/Extensions/MessageTests.cs
+++ b/laget.Azure.ServiceBus.Tests/Extensions/MessageTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Reflection;
+using System.Text;
 using laget.Azure.ServiceBus.Extensions;
 using Xunit;
 
@@ -6,14 +8,51 @@ namespace laget.Azure.ServiceBus.Tests.Extensions
 {
     public class MessageTests
     {
+        private Microsoft.Azure.ServiceBus.Message _servicebusMessage;
+
+        public MessageTests()
+        {
+            // One-time setup
+            // Only use this setup for testing, do not attempt to set systemproperties in production
+            _servicebusMessage = new Microsoft.Azure.ServiceBus.Message { MessageId = "SomeCoolId1" };
+
+            var systemProperties = new Microsoft.Azure.ServiceBus.Message.SystemPropertiesCollection();
+            var bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
+
+            var sequenceNumber = 1;
+            var enqueueTime = DateTime.Now.AddSeconds(5);
+            systemProperties.GetType().InvokeMember("EnqueuedTimeUtc", bindings, Type.DefaultBinder, systemProperties, new object[] { enqueueTime } );
+            systemProperties.GetType().InvokeMember("SequenceNumber", bindings, Type.DefaultBinder, systemProperties, new object[] { sequenceNumber });
+
+            // Set mocked-up systemprorperties for current message
+            bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
+            _servicebusMessage.GetType().InvokeMember("SystemProperties", bindings, Type.DefaultBinder, _servicebusMessage, new object[] { systemProperties });
+        }
+
         [Fact]
         public void ShouldDeserializeMessage()
         {
-            var body = Encoding.UTF8.GetBytes("{ \"name\": \"Jane Doe\" }");
-            var message = new Microsoft.Azure.ServiceBus.Message { Body = body };
+            _servicebusMessage.Body = Encoding.UTF8.GetBytes("{ \"Name\": \"Jane Doe\" }");
+            var model = _servicebusMessage.Deserialize<Models.User>();
 
-            var model = message.Deserialize<Models.User>();
+            Assert.Equal("Jane Doe", model.Name);
+        }
 
+        [Fact]
+        public void ShouldConvertMessage()
+        {
+            var userMessage = new Models.User
+            {
+                Category = "UserCategory",
+                CreatedAt = DateTime.Now,
+                Id = "UserId1",
+                Name = "Jane Doe",
+                Type = "UserType"
+            };
+
+            var servicebusMessage = userMessage.ToServicebusMessage();
+            var model = servicebusMessage.Deserialize<Models.User>();
+        
             Assert.Equal("Jane Doe", model.Name);
         }
     }

--- a/laget.Azure.ServiceBus.Tests/Extensions/MessageTests.cs
+++ b/laget.Azure.ServiceBus.Tests/Extensions/MessageTests.cs
@@ -50,7 +50,7 @@ namespace laget.Azure.ServiceBus.Tests.Extensions
                 Type = "UserType"
             };
 
-            var servicebusMessage = userMessage.ToServicebusMessage();
+            var servicebusMessage = userMessage.ToServiceBusMessage();
             var model = servicebusMessage.Deserialize<Models.User>();
         
             Assert.Equal("Jane Doe", model.Name);

--- a/laget.Azure.ServiceBus/Extensions/Message.cs
+++ b/laget.Azure.ServiceBus/Extensions/Message.cs
@@ -18,5 +18,13 @@ namespace laget.Azure.ServiceBus.Extensions
 
             return entity;
         }
+
+        public static Microsoft.Azure.ServiceBus.Message ConvertToServicebusMessage(this IMessage message)
+        {
+            var json = message.Serialize();
+            var bytes = Encoding.UTF8.GetBytes(json);
+
+            return new Microsoft.Azure.ServiceBus.Message(bytes);
+        }
     }
 }

--- a/laget.Azure.ServiceBus/Extensions/Message.cs
+++ b/laget.Azure.ServiceBus/Extensions/Message.cs
@@ -19,7 +19,7 @@ namespace laget.Azure.ServiceBus.Extensions
             return entity;
         }
 
-        public static Microsoft.Azure.ServiceBus.Message ConvertToServicebusMessage(this IMessage message)
+        public static Microsoft.Azure.ServiceBus.Message ToServicebusMessage(this IMessage message)
         {
             var json = message.Serialize();
             var bytes = Encoding.UTF8.GetBytes(json);

--- a/laget.Azure.ServiceBus/Extensions/Message.cs
+++ b/laget.Azure.ServiceBus/Extensions/Message.cs
@@ -19,7 +19,7 @@ namespace laget.Azure.ServiceBus.Extensions
             return entity;
         }
 
-        public static Microsoft.Azure.ServiceBus.Message ToServicebusMessage(this IMessage message)
+        public static Microsoft.Azure.ServiceBus.Message ToServiceBusMessage(this IMessage message)
         {
             var json = message.Serialize();
             var bytes = Encoding.UTF8.GetBytes(json);

--- a/laget.Azure.ServiceBus/Topic/TopicSender.cs
+++ b/laget.Azure.ServiceBus/Topic/TopicSender.cs
@@ -10,8 +10,10 @@ namespace laget.Azure.ServiceBus.Topic
     public interface ITopicSender
     {
         Task SendAsync(IMessage message);
+        Task SendAsync(IEnumerable<IMessage> messageList);
         Task ScheduleAsync(IMessage message, DateTimeOffset offset);
         Task SendAsync(string json);
+        Task SendAsync(IEnumerable<string> messageList);
         Task ScheduleAsync(string json, DateTimeOffset offset);
     }
 
@@ -29,7 +31,7 @@ namespace laget.Azure.ServiceBus.Topic
             await _client.SendAsync(message.ToServiceBusMessage());
         }
 
-        public async Task SendAsync(IList<IMessage> messageList)
+        public async Task SendAsync(IEnumerable<IMessage> messageList)
         {
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 
@@ -51,7 +53,7 @@ namespace laget.Azure.ServiceBus.Topic
             await _client.SendAsync(new Microsoft.Azure.ServiceBus.Message(bytes));
         }
 
-        public async Task SendAsync(IList<string> messageList)
+        public async Task SendAsync(IEnumerable<string> messageList)
         {
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 

--- a/laget.Azure.ServiceBus/Topic/TopicSender.cs
+++ b/laget.Azure.ServiceBus/Topic/TopicSender.cs
@@ -10,10 +10,10 @@ namespace laget.Azure.ServiceBus.Topic
     public interface ITopicSender
     {
         Task SendAsync(IMessage message);
-        Task SendAsync(IEnumerable<IMessage> messageList);
+        Task SendAsync(IEnumerable<IMessage> messages);
         Task ScheduleAsync(IMessage message, DateTimeOffset offset);
         Task SendAsync(string json);
-        Task SendAsync(IEnumerable<string> messageList);
+        Task SendAsync(IEnumerable<string> messages);
         Task ScheduleAsync(string json, DateTimeOffset offset);
     }
 
@@ -31,11 +31,11 @@ namespace laget.Azure.ServiceBus.Topic
             await _client.SendAsync(message.ToServiceBusMessage());
         }
 
-        public async Task SendAsync(IEnumerable<IMessage> messageList)
+        public async Task SendAsync(IEnumerable<IMessage> messages)
         {
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 
-            foreach (var message in messageList)
+            foreach (var message in messages)
                 sendList.Add(message.ToServiceBusMessage());
 
             await _client.SendAsync(sendList);
@@ -53,11 +53,11 @@ namespace laget.Azure.ServiceBus.Topic
             await _client.SendAsync(new Microsoft.Azure.ServiceBus.Message(bytes));
         }
 
-        public async Task SendAsync(IEnumerable<string> messageList)
+        public async Task SendAsync(IEnumerable<string> messages)
         {
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 
-            foreach (var message in messageList)
+            foreach (var message in messages)
                 sendList.Add(new Microsoft.Azure.ServiceBus.Message(Encoding.UTF8.GetBytes(message)));
 
             await _client.SendAsync(sendList);

--- a/laget.Azure.ServiceBus/Topic/TopicSender.cs
+++ b/laget.Azure.ServiceBus/Topic/TopicSender.cs
@@ -26,7 +26,7 @@ namespace laget.Azure.ServiceBus.Topic
 
         public async Task SendAsync(IMessage message)
         {
-            await _client.SendAsync(message.ToServicebusMessage());
+            await _client.SendAsync(message.ToServiceBusMessage());
         }
 
         public async Task SendAsync(IList<IMessage> messageList)
@@ -34,14 +34,14 @@ namespace laget.Azure.ServiceBus.Topic
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 
             foreach (var message in messageList)
-                sendList.Add(message.ToServicebusMessage());
+                sendList.Add(message.ToServiceBusMessage());
 
             await _client.SendAsync(sendList);
         }
 
         public async Task ScheduleAsync(IMessage message, DateTimeOffset offset)
         {
-            await _client.ScheduleMessageAsync(message.ToServicebusMessage(), offset);
+            await _client.ScheduleMessageAsync(message.ToServiceBusMessage(), offset);
         }
 
         public async Task SendAsync(string json)

--- a/laget.Azure.ServiceBus/Topic/TopicSender.cs
+++ b/laget.Azure.ServiceBus/Topic/TopicSender.cs
@@ -26,22 +26,22 @@ namespace laget.Azure.ServiceBus.Topic
 
         public async Task SendAsync(IMessage message)
         {
-            await _client.SendAsync(message.ConvertToServicebusMessage());
+            await _client.SendAsync(message.ToServicebusMessage());
         }
 
         public async Task SendAsync(IList<IMessage> messageList)
         {
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 
-            foreach (var m in messageList)
-                sendList.Add(m.ConvertToServicebusMessage());
+            foreach (var message in messageList)
+                sendList.Add(message.ToServicebusMessage());
 
             await _client.SendAsync(sendList);
         }
 
         public async Task ScheduleAsync(IMessage message, DateTimeOffset offset)
         {
-            await _client.ScheduleMessageAsync(message.ConvertToServicebusMessage(), offset);
+            await _client.ScheduleMessageAsync(message.ToServicebusMessage(), offset);
         }
 
         public async Task SendAsync(string json)
@@ -55,8 +55,8 @@ namespace laget.Azure.ServiceBus.Topic
         {
             var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
 
-            foreach (var m in messageList)
-                sendList.Add(new Microsoft.Azure.ServiceBus.Message(Encoding.UTF8.GetBytes(m)));
+            foreach (var message in messageList)
+                sendList.Add(new Microsoft.Azure.ServiceBus.Message(Encoding.UTF8.GetBytes(message)));
 
             await _client.SendAsync(sendList);
         }

--- a/laget.Azure.ServiceBus/Topic/TopicSender.cs
+++ b/laget.Azure.ServiceBus/Topic/TopicSender.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.ServiceBus;
+using laget.Azure.ServiceBus.Extensions;
 
 namespace laget.Azure.ServiceBus.Topic
 {
@@ -22,13 +24,22 @@ namespace laget.Azure.ServiceBus.Topic
             _client = new TopicClient(connectionString, options.TopicName, options.RetryPolicy);
         }
 
-
         public async Task SendAsync(IMessage message)
         {
             var json = message.Serialize();
             var bytes = Encoding.UTF8.GetBytes(json);
 
             await _client.SendAsync(new Microsoft.Azure.ServiceBus.Message(bytes));
+        }
+
+        public async Task SendAsync(IList<IMessage> messageList)
+        {
+            var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
+
+            foreach (var m in messageList)
+                sendList.Add(m.ConvertToServicebusMessage());
+
+            await _client.SendAsync(sendList);
         }
 
         public async Task ScheduleAsync(IMessage message, DateTimeOffset offset)
@@ -44,6 +55,16 @@ namespace laget.Azure.ServiceBus.Topic
             var bytes = Encoding.UTF8.GetBytes(json);
 
             await _client.SendAsync(new Microsoft.Azure.ServiceBus.Message(bytes));
+        }
+
+        public async Task SendAsync(IList<string> messageList)
+        {
+            var sendList = new List<Microsoft.Azure.ServiceBus.Message>();
+
+            foreach (var m in messageList)
+                sendList.Add(new Microsoft.Azure.ServiceBus.Message(Encoding.UTF8.GetBytes(m)));
+
+            await _client.SendAsync(sendList);
         }
 
         public async Task ScheduleAsync(string json, DateTimeOffset offset)

--- a/laget.Azure.ServiceBus/Topic/TopicSender.cs
+++ b/laget.Azure.ServiceBus/Topic/TopicSender.cs
@@ -26,10 +26,7 @@ namespace laget.Azure.ServiceBus.Topic
 
         public async Task SendAsync(IMessage message)
         {
-            var json = message.Serialize();
-            var bytes = Encoding.UTF8.GetBytes(json);
-
-            await _client.SendAsync(new Microsoft.Azure.ServiceBus.Message(bytes));
+            await _client.SendAsync(message.ConvertToServicebusMessage());
         }
 
         public async Task SendAsync(IList<IMessage> messageList)
@@ -44,10 +41,7 @@ namespace laget.Azure.ServiceBus.Topic
 
         public async Task ScheduleAsync(IMessage message, DateTimeOffset offset)
         {
-            var json = message.Serialize();
-            var bytes = Encoding.UTF8.GetBytes(json);
-
-            await _client.ScheduleMessageAsync(new Microsoft.Azure.ServiceBus.Message(bytes), offset);
+            await _client.ScheduleMessageAsync(message.ConvertToServicebusMessage(), offset);
         }
 
         public async Task SendAsync(string json)


### PR DESCRIPTION
Dessa ändringar komma introducera möjligheten att skicka in en lista med meddelanden till SendAsync under TopicSender. Vilket kommer förhoppningsvis kunna motverka en del upplevda throttling-problem som har setts mot Azure Servicebus.

Finns ej implementerat någonstans ännu. Vikt ligger på kodgranskning 